### PR TITLE
Added PhantomJS as a gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ group :test, :development do
   gem "byebug"
   gem "rspec-rails"
   gem "teaspoon-jasmine"
+  gem "phantomjs"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,6 +213,7 @@ GEM
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     non-stupid-digest-assets (1.0.4)
+    phantomjs (1.9.8.0)
     poltergeist (1.6.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -385,6 +386,7 @@ DEPENDENCIES
   mysql2
   newrelic_rpm
   nokogiri
+  phantomjs
   poltergeist
   quiet_assets
   rack-cache
@@ -400,3 +402,6 @@ DEPENDENCIES
   timecop
   uglifier
   validates_email_format_of
+
+BUNDLED WITH
+   1.10.6


### PR DESCRIPTION
Added PhantomJS as a :test and :development dependency in the Gemfile, since setting this up on a new system raised the error the PhantomJS didn't exist.